### PR TITLE
Update train_imagenet.py

### DIFF
--- a/train_imagenet.py
+++ b/train_imagenet.py
@@ -9,6 +9,7 @@ import re
 import numpy as np
 
 from synset import *
+from resnet import inference
 from image_processing import image_preprocessing
 
 FLAGS = tf.app.flags.FLAGS


### PR DESCRIPTION
Add the import line to fix a bug of missing importing 'inference' function from resnet.py.